### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ do_action(
 
   ### Allow only registered users to react
 
-  By default, reactions will be saved to user meta to allow users to react once per post. If this is set to `false`, use localstorage and [FingerprintJS](https://github.com/fingerprintjs/fingerprintjs) to set browser fingerprints to reaction events and save the reactions to the posts only.
+  If this is set to `true`, only logged in users can react. On default mode where everyone can react, use localstorage and [FingerprintJS](https://github.com/fingerprintjs/fingerprintjs) to set browser fingerprints to reaction events and save the reactions to the posts only. If limited to logged in users only, reactions will be saved to user meta to allow users to react once per post. 
 
-  Default: `true`
+  Default: `false`
 
   ```
   add_filter( 'air_reactions_require_login', function( (bool) $require_login ) {


### PR DESCRIPTION
Update the documentation and default value for `air_reactions_require_login` filter as `DEFAULT_REQUIRE_LOGIN` was changed in the https://github.com/digitoimistodude/air-reactions/commit/9c1f68aa0f7646075ab6a6e82309e4ab23fcb7be but not reflected on the documentation.